### PR TITLE
Markdown support

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,8 @@
         "@mdi/font": "^7.2.96",
         "aws-amplify": "^5.2.3",
         "buefy": "github:kikuomax/buefy#v0.9.21-vue3-2",
+        "dompurify": "^3.0.5",
+        "marked": "^5.1.2",
         "pinia": "^2.0.36",
         "vue": "^3.3.2",
         "vue-router": "^4.2.0"
@@ -25,7 +27,9 @@
         "@aws-sdk/shared-ini-file-loader": "^3.347.0",
         "@rushstack/eslint-patch": "^1.2.0",
         "@tsconfig/node18": "^2.0.1",
+        "@types/dompurify": "^3.0.2",
         "@types/jsdom": "^21.1.1",
+        "@types/marked": "^5.0.1",
         "@types/node": "^18.16.8",
         "@vitejs/plugin-vue": "^4.2.3",
         "@vue/eslint-config-prettier": "^7.1.0",
@@ -16467,6 +16471,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.2.tgz",
+      "integrity": "sha512-YBL4ziFebbbfQfH5mlC+QTJsvh0oJUrWbmxKMyEdL7emlHJqGR2Qb34TEFKj+VCayBvjKy3xczMFNhugThUsfQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -16508,6 +16521,12 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
+    "node_modules/@types/marked": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Y3pAUzHKh605fN6fvASsz5FDSWbZcs/65Q6xYRmnIP9ZIYz27T4IOmXfH9gWJV1dpi7f1e7z7nBGUTx/a0ptpA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.16.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.15.tgz",
@@ -16541,6 +16560,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -19188,6 +19213,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -22753,6 +22783,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/md5-hex": {
@@ -41599,6 +41640,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
+    "@types/dompurify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.2.tgz",
+      "integrity": "sha512-YBL4ziFebbbfQfH5mlC+QTJsvh0oJUrWbmxKMyEdL7emlHJqGR2Qb34TEFKj+VCayBvjKy3xczMFNhugThUsfQ==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -41640,6 +41690,12 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
+    "@types/marked": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Y3pAUzHKh605fN6fvASsz5FDSWbZcs/65Q6xYRmnIP9ZIYz27T4IOmXfH9gWJV1dpi7f1e7z7nBGUTx/a0ptpA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.16.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.15.tgz",
@@ -41673,6 +41729,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "@types/yargs": {
@@ -43697,6 +43759,11 @@
       "requires": {
         "webidl-conversions": "^7.0.0"
       }
+    },
+    "dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "dot-case": {
       "version": "3.0.4",
@@ -46417,6 +46484,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg=="
     },
     "md5-hex": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,8 @@
     "@mdi/font": "^7.2.96",
     "aws-amplify": "^5.2.3",
     "buefy": "github:kikuomax/buefy#v0.9.21-vue3-2",
+    "dompurify": "^3.0.5",
+    "marked": "^5.1.2",
     "pinia": "^2.0.36",
     "vue": "^3.3.2",
     "vue-router": "^4.2.0"
@@ -34,7 +36,9 @@
     "@aws-sdk/shared-ini-file-loader": "^3.347.0",
     "@rushstack/eslint-patch": "^1.2.0",
     "@tsconfig/node18": "^2.0.1",
+    "@types/dompurify": "^3.0.2",
     "@types/jsdom": "^21.1.1",
+    "@types/marked": "^5.0.1",
     "@types/node": "^18.16.8",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vue/eslint-config-prettier": "^7.1.0",

--- a/app/src/assets/markdown.css
+++ b/app/src/assets/markdown.css
@@ -1,0 +1,48 @@
+/* adds my preference to Bulma's content style */
+.content {
+  & .markdown-content,
+  &.markdown-content {
+    & code {
+      color: inherit;
+    }
+
+    & ul {
+      list-style-position: inside;
+      list-style-type: disc;
+
+      & ul {
+        list-style-type: square;
+
+        & ul {
+          list-style-type: circle;
+
+          & ul {
+            list-style-type: "\25AB";
+          }
+        }
+      }
+    }
+
+    & ol {
+      list-style-position: inside;
+
+      & ol {
+        list-style-type: lower-alpha;
+
+        & ol {
+          list-style-type: lower-roman;
+
+          & ol {
+            list-style-type: decimal;
+          }
+        }
+      }
+    }
+
+    & table {
+      & th {
+        font-weight: 600;
+      }
+    }
+  }
+}

--- a/app/src/components/Post.vue
+++ b/app/src/components/Post.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
+import DOMPurify from 'dompurify'
+import { computed } from 'vue'
+
 import type { Post } from '@/types/post'
 
-defineProps<{
+const props = defineProps<{
   post: Post,
 }>()
+
+const safeContent = computed(() => {
+  return DOMPurify.sanitize(props.post.content)
+})
 </script>
 
 <template>
   <div class="card block">
     <div class="card-content">
       <div class="content">
-        <p class="post-content">{{ post.content }}</p>
+        <div class="post-content markdown-content" v-html="safeContent"></div>
         <p class="post-date">{{ post.published }}</p>
       </div>
     </div>

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,4 +1,5 @@
 import './assets/main.css'
+import './assets/markdown.css'
 
 import { Amplify } from 'aws-amplify'
 

--- a/app/src/types/post.ts
+++ b/app/src/types/post.ts
@@ -16,6 +16,9 @@ export interface Post {
   /** Content of the post. */
   content: string
 
+  /** Source of the post. */
+  source?: PostSource
+
   /** "to". */
   to: string[]
 
@@ -24,6 +27,19 @@ export interface Post {
 
   /** Optional attachments. */
   attachment?: AttachmentLink[]
+}
+
+/**
+ * Source of a post.
+ *
+ * @beta
+ */
+export interface PostSource {
+  /** Content of the source. */
+  content: string
+
+  /** MIME-type of the source content. */
+  mediaType: string
 }
 
 /**


### PR DESCRIPTION
The post editor parses the input text as Markdown and posts the output HTML as the `content` of the post. It includes the original Markdown text in `source` property. Thanks to Markdown parsing, URLs are converted to links.
- close #1 
- close #3